### PR TITLE
bugfix: use alternate CSS classes to hide skill card backface on Firefox

### DIFF
--- a/src/client/components/atoms/SkillCard/SkillCard.tsx
+++ b/src/client/components/atoms/SkillCard/SkillCard.tsx
@@ -3,6 +3,12 @@
 import { sendGAEvent } from "@next/third-parties/google";
 import React, { useEffect, useRef, useState } from "react";
 
+// To avoid a bug related with backface-visibility on Firefox we have to bypass this CSS property
+// First identifying the navigator
+// Reference: https://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browsers
+// @ts-ignore
+const isFirefox = typeof InstallTrigger !== 'undefined';
+
 interface SkillCardProps {
   Icon: React.JSX.Element;
   tags: string[];
@@ -15,6 +21,8 @@ export const SkillCard = ({ Icon, tags, title }: SkillCardProps) => {
   const [rotateCard, setRotateCard] = useState(false);
 
   const ref = useRef(null);
+
+  const hideBackfaceClass = isFirefox && rotateCard ? "hidden" : "backface-hidden"
 
   useEffect(() => {
     const observer = new IntersectionObserver(([entry]) => {
@@ -56,14 +64,14 @@ export const SkillCard = ({ Icon, tags, title }: SkillCardProps) => {
       <div
         className={`relative preserve-3d ${rotateCardClass} w-full h-[115px] duration-1000 p-4 rounded-lg border-solid border-[1px] border-[#C9C9C9] dark:border-[#334D66] bg-[#E8EDF2] dark:bg-[#1A2633]`}
       >
-        <div className="backface-hidden w-full h-full flex flex-col justify-center align-middle items-center">
+        <div className={`${hideBackfaceClass} w-full h-full flex flex-col justify-center align-middle items-center`}>
           {Icon}
           <p className="font-medium mt-3 text-primary-dark dark:text-primary-light md:text-lg">
             {title}
           </p>
         </div>
 
-        <div className="absolute top-0 left-0  p-4 my-rotate-y-180 backface-hidden w-full h-full overflow-hidden flex justify-center items-center text-primary-dark dark:text-primary-light">
+        <div className="backface-hidden my-rotate-y-180 absolute top-0 left-0 p-4 w-full h-full overflow-hidden flex justify-center items-center text-primary-dark dark:text-primary-light">
           <p className="text-center text-xs md:text-base lg:text-lg">{tags.join(", ")}</p>
         </div>
       </div>

--- a/src/client/components/atoms/SkillCard/SkillCard.tsx
+++ b/src/client/components/atoms/SkillCard/SkillCard.tsx
@@ -4,7 +4,7 @@ import { sendGAEvent } from "@next/third-parties/google";
 import React, { useEffect, useRef, useState } from "react";
 
 // To avoid a bug related with backface-visibility on Firefox we have to bypass this CSS property
-// First identifying the navigator
+// First identifying the browser
 // Reference: https://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browsers
 // @ts-ignore
 const isFirefox = typeof InstallTrigger !== 'undefined';

--- a/src/client/components/atoms/SkillCard/SkillCard.tsx
+++ b/src/client/components/atoms/SkillCard/SkillCard.tsx
@@ -4,7 +4,6 @@ import { sendGAEvent } from "@next/third-parties/google";
 import React, { useEffect, useRef, useState } from "react";
 
 // To avoid a bug related with backface-visibility on Firefox we have to bypass this CSS property
-// First identifying the browser
 // Reference: https://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browsers
 // @ts-ignore
 const isFirefox = typeof InstallTrigger !== 'undefined';
@@ -22,8 +21,6 @@ export const SkillCard = ({ Icon, tags, title }: SkillCardProps) => {
 
   const ref = useRef(null);
 
-  const hideBackfaceClass = isFirefox && rotateCard ? "hidden" : "backface-hidden"
-
   useEffect(() => {
     const observer = new IntersectionObserver(([entry]) => {
       setIntersecting(entry.isIntersecting);
@@ -40,6 +37,10 @@ export const SkillCard = ({ Icon, tags, title }: SkillCardProps) => {
   const opacity = isIntersecting ? "opacity-100" : "opacity-0";
 
   const rotateCardClass = rotateCard ? "my-rotate-y-180" : "";
+
+  const browserDependantClasses = isFirefox ?
+    ["transition-[opacity]", "delay-[250ms]", `${rotateCard ? "opacity-0" : "opacity-100"}`].join(" ")
+    : "backface-hidden"
 
   const handleToggleRotate = () => {
     setRotateCard((state) => !state);
@@ -64,7 +65,7 @@ export const SkillCard = ({ Icon, tags, title }: SkillCardProps) => {
       <div
         className={`relative preserve-3d ${rotateCardClass} w-full h-[115px] duration-1000 p-4 rounded-lg border-solid border-[1px] border-[#C9C9C9] dark:border-[#334D66] bg-[#E8EDF2] dark:bg-[#1A2633]`}
       >
-        <div className={`${hideBackfaceClass} w-full h-full flex flex-col justify-center align-middle items-center`}>
+        <div className={`${browserDependantClasses} w-full h-full flex flex-col justify-center align-middle items-center`}>
           {Icon}
           <p className="font-medium mt-3 text-primary-dark dark:text-primary-light md:text-lg">
             {title}


### PR DESCRIPTION
There's a known bug in Firefox that prevents the use of the CSS property `backface-visibility`.

To bypass this bug, we identify the browser and change the opacity of the layer, with a smooth transition using Tailwind classes.

Reference: https://stackoverflow.com/questions/9604982/backface-visibility-not-working-properly-in-firefox-works-in-safari